### PR TITLE
feat: Add participation schema.

### DIFF
--- a/src/corpore/index.ts
+++ b/src/corpore/index.ts
@@ -4,3 +4,4 @@ export * from './session-rpe';
 export * from './team';
 export * from './user-statistic';
 export * from './wellness';
+export * from './participation';

--- a/src/corpore/participation.ts
+++ b/src/corpore/participation.ts
@@ -1,0 +1,74 @@
+import moment from 'moment';
+
+import { UUID } from 'angular2-uuid';
+
+import { 
+    IDataPoint,
+    ITimeFrame,
+    CurrentDateTimeFrame,
+    ISchemaID,
+    SchemaID,
+    SchemaVersion,
+    IHeader, 
+    PMSYS_2_0_PROVENANCE
+} from '../omh/index';
+
+const PARTICIPATION_1_0_SCHEMA:ISchemaID = new SchemaID("corporesano", "participation", new SchemaVersion(1,0));
+
+class PMSYSRPEHeader implements IHeader {
+    id = UUID.UUID();
+    creation_date_time = moment.tz(moment.tz.guess()).toDate();
+    schema_id: ISchemaID = PARTICIPATION_1_0_SCHEMA;
+    acuisition_provenance = PMSYS_2_0_PROVENANCE;
+
+    constructor(public user_id: string) {};
+
+}
+
+export interface IParticipation{
+    effective_time_frame: ITimeFrame;
+    going: string;
+    comment: string;
+}
+
+export class Participation implements IParticipation{
+    static fromBasicValues (
+        going: string,
+        comment: string) {
+        return new Participation(new CurrentDateTimeFrame(), going, comment);
+    }
+
+    constructor(
+        public effective_time_frame: ITimeFrame,
+        public going: string,
+        public comment: string
+    ) {};
+}
+
+export function isParticipation(t:any): t is IParticipation {
+    let i = t as IParticipation;
+    if (i.effective_time_frame === undefined) { return false; }
+    if (i.going === undefined) { return false; }
+    if (i.comment === undefined) { return false; }
+    return true;    
+}
+
+class ParticipationHeader implements IHeader {
+    id = UUID.UUID();
+    creation_date_time = moment.tz(moment.tz.guess()).toDate();
+    schema_id: ISchemaID =  PARTICIPATION_1_0_SCHEMA;
+    acuisition_provenance = PMSYS_2_0_PROVENANCE;
+
+    constructor(public user_id: string) {};
+}
+
+export class ParticipationDataPoint implements IDataPoint<IParticipation> {
+    
+    header:IHeader;
+    body: IParticipation;
+        
+    constructor(user_id: string, body: IParticipation) {
+        this.header = new ParticipationHeader(user_id);
+        this.body = body;
+    };
+}


### PR DESCRIPTION
New report for participation. Users can report if they are going to the next training session. Typical response is 'yes', 'no', 'maybe' with an optional comment.

Please suggest improvements to schema.